### PR TITLE
CockroachDB configuration rewrite

### DIFF
--- a/new-config/Chart.yaml
+++ b/new-config/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: cockroachdb
+version: 0.1.0

--- a/new-config/README.md
+++ b/new-config/README.md
@@ -1,0 +1,22 @@
+# Multi-region cockroachdb setup
+
+1. Make sure your `$KUBECONFIG` is pointed to the proper cluster and your context is set accordingly.
+2. Ensure cockroach binary is installed and is able to be run with `cockroach version`. We use this to generate the certs in the python script.
+3. Install helm because it is needed to generate the templates. (would like to transition to kustomize later on since its natively supported in kubectl)
+4. Be sure to run all scripts from within this directory.
+5. Uncomment and fill out the **create_clusters** section in the python script with a namespace and context.
+
+   Run the `make-certs.py` script to generate the certs
+
+   > `python2.7 make-certs.py`
+
+   This script does 3 things:
+
+- Generates a public-facing loadbalancer in the designated namespace.
+- Builds a certificate directory structure
+- Creates certificates within their respective directory to be used by the `apply-certs.sh` script.
+
+5. Fill out the `NAMESPACE` and `CLUSTER_INIT` variables at the top of `apply-certs.sh` and then run it to load the secrets into the script. This script will delete existing secrets on the cluster named `cockroachdb.client.root` and it will also create secrets on the cluster containing the certificates that were generated from the python script.
+6. Fill out the `values.yaml` file with at minimum the PublicAddr, namespace, and storageClass values.
+7. Run `helm template . > cockroachdb.yaml` to render the YAML.
+8. Run `kubectl apply -f cockroackdb.yaml` to apply it to the cluster.

--- a/new-config/apply-certs.sh
+++ b/new-config/apply-certs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Paths to directories in which to store certificates and generated YAML files.
+NAMESPACE=
+CLUSTER_INIT=
+CLIENTS_CERTS_DIR=$(pwd)/generated/$NAMESPACE/client_certs_dir
+NODE_CERTS_DIR=$(pwd)/generated/$NAMESPACE/node_certs_dir
+DIR=$(pwd)
+CONTEXT=$(kubectl config get-contexts -o name)
+TEMPLATES_DIR=$DIR/templates
+# ------------------------------------------------------------------------------
+
+# Delete previous secrets in case they have changed
+kubectl delete secret cockroachdb.client.root --context $CONTEXT 
+kubectl delete secret cockroachdb.client.root --namespace $NAMESPACE --context $CONTEXT
+kubectl delete secret cockroachdb.node --namespace $NAMESPACE --context $CONTEXT 
+# Now we can set up the certs since we can get the lbs ip address.
+kubectl create secret generic cockroachdb.client.root --from-file $CLIENTS_CERTS_DIR --context $CONTEXT 
+kubectl create secret generic cockroachdb.client.root --namespace $NAMESPACE --from-file $CLIENTS_CERTS_DIR --context $CONTEXT
+kubectl create secret generic cockroachdb.node --namespace $NAMESPACE --from-file $NODE_CERTS_DIR --context $CONTEXT 

--- a/new-config/make-certs.py
+++ b/new-config/make-certs.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+
+import distutils.spawn
+import json
+import os
+import stat
+from subprocess import check_call, check_output
+from sys import exit
+from time import sleep
+
+# This script builds a loadbalancer in the specified namespace and context and then generates certificates.
+
+
+class CockroachCluster():
+
+    def __init__(self, namespace, context='', lb_ip='', ca_certs_file=''):
+        self.namespace = namespace
+        self.context = context
+        self.lb_ip = lb_ip
+        if ca_certs_file:
+            self.ca_certs_file = ca_certs_file
+
+    @property
+    def directory(self):
+        return os.path.join('./generated/', self.namespace)
+
+    @property
+    def ca_certs_file(self):
+        return os.path.join(self.ca_certs_dir, 'ca.crt')
+
+    @property
+    def ca_certs_dir(self):
+        return os.path.join(self.directory, 'ca_certs_dir')
+
+    @property
+    def client_certs_dir(self):
+        return os.path.join(self.directory, 'client_certs_dir')
+
+    @property
+    def node_certs_dir(self):
+        return os.path.join(self.directory, 'node_certs_dir')
+
+# EDIT/UNCOMMENT THIS!!
+
+# create_clusters = [
+#     CockroachCluster(
+#         namespace='',
+#         context='',
+#     ),
+# ]
+
+
+join_clusters = [
+    # CockroachCluster(
+    #   lb_ip='external_ip_address',
+    #   ca_certs_file='path_to_ca_public_cert',
+    # ),
+]
+
+# Create cert folders, create the namespace, and apply the loadbalancer yaml.
+for cr in create_clusters:
+    try:
+        os.mkdir('./generated')
+    except OSError:
+        pass
+    try:
+        os.mkdir(cr.directory)
+    except OSError:
+        pass
+    try:
+        check_call(['kubectl', 'create', 'namespace',
+                    cr.namespace, '--context', cr.context])
+    except:
+        pass
+    try:
+        check_call(['kubectl', 'apply', '-f', './templates/loadbalancer.yaml',
+                    '--namespace', cr.namespace, '--context', cr.context])
+    except:
+        pass
+
+# Create/grab the load balancer IP(s)
+for cr in create_clusters:
+    external_ip = ''
+    while True:
+        external_ip = check_output(['kubectl', 'get', 'svc', 'cockroachdb-public', '--namespace', cr.namespace,
+                                    '--context', cr.context, '--template', '{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}'])
+        if external_ip:
+            break
+        print 'Waiting for load balancer IP in %s...' % (cr.namespace)
+        sleep(10)
+    print 'LB endpoint for namespace %s: %s ' % (cr.namespace, external_ip)
+    cr.lb_ip = external_ip
+
+# Build CA certs file
+
+for cr in create_clusters:
+    try:
+        check_call('rm -r %s' % (cr.ca_certs_dir), shell=True)
+    except:
+        pass
+    os.mkdir(cr.ca_certs_dir)
+    check_call(['cockroach', 'cert', 'create-ca', '--certs-dir',
+                cr.ca_certs_dir, '--ca-key', cr.ca_certs_dir+'/ca.key'])
+
+for cr in create_clusters:
+    for cr_join in create_clusters + join_clusters:
+        if cr == cr_join:
+            continue
+        check_call(['cat %s >> %s' %
+                    (cr_join.ca_certs_file, cr.ca_certs_file)], shell=True)
+
+
+# Now we can set up the certs since we can get the lb's ip address.
+
+# Build node and client certs
+for cr in create_clusters:
+    try:
+        check_call('rm -r %s' % (cr.node_certs_dir), shell=True)
+    except:
+        pass
+    try:
+        check_call('rm -r %s' % (cr.client_certs_dir), shell=True)
+    except:
+        pass
+    os.mkdir(cr.client_certs_dir)
+    os.mkdir(cr.node_certs_dir)
+    check_call(['cp', cr.ca_certs_file, cr.client_certs_dir])
+    check_call(['cockroach', 'cert', 'create-client', 'root', '--certs-dir',
+                cr.client_certs_dir, '--ca-key', cr.ca_certs_dir+'/ca.key'])
+
+    check_call(['cp %s %s ' % (cr.client_certs_dir +
+                               '/*', cr.node_certs_dir)], shell=True)
+
+    check_call(['cockroach', 'cert', 'create-node', '--certs-dir', cr.node_certs_dir, '--ca-key', cr.ca_certs_dir+'/ca.key', cr.lb_ip, 'localhost', '127.0.0.1', 'cockroachdb-public', 'cockroachdb-public.default',
+                'cockroachdb-public.'+cr.namespace, 'cockroachdb-public.%s.svc.cluster.local' % (cr.namespace), '*.cockroachdb', '*.cockroachdb.'+cr.namespace, '*.cockroachdb.%s.svc.cluster.local' % (cr.namespace)])

--- a/new-config/templates/cluster-init-secure.yaml
+++ b/new-config/templates/cluster-init-secure.yaml
@@ -1,0 +1,31 @@
+{{- if eq .Values.clusterInit true }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cluster-init-secure
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ .Chart.Name }}
+      containers:
+      - name: cluster-init
+        image: {{ .Values.image }}
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: client-certs
+          mountPath: /cockroach-certs
+        command:
+          - "/cockroach/cockroach"
+          - "init"
+          - "--certs-dir=/cockroach-certs"
+          - "--host={{ .Chart.Name }}-0.{{ .Chart.Name }}"
+      restartPolicy: OnFailure
+      volumes:
+      - name: client-certs
+        secret:
+          secretName: cockroachdb.client.root
+          defaultMode: 256
+{{- end }}

--- a/new-config/templates/cockroachdb-statefulset-secure.yaml
+++ b/new-config/templates/cockroachdb-statefulset-secure.yaml
@@ -1,0 +1,210 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Values.namespace}}
+  labels:
+    app: {{ .Chart.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Values.namespace}}
+  labels:
+    app: {{ .Chart.Name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+rules:
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - create
+  - get
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Values.namespace}}
+  labels:
+    app: {{ .Chart.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Chart.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Chart.Name }}
+  namespace: {{ .Values.namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Chart.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Chart.Name }}
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # This service only exists to create DNS entries for each pod in the stateful
+  # set such that they can resolve each other's IP addresses. It does not
+  # create a load-balanced ClusterIP and should not be used directly by clients
+  # in most circumstances.
+  name: {{ .Chart.Name }}
+  namespace: {{ .Values.namespace}}
+  labels:
+    app: {{ .Chart.Name }}
+  annotations:
+    # Use this annotation in addition to the actual publishNotReadyAddresses
+    # field below because the annotation will stop being respected soon but the
+    # field is broken in some versions of Kubernetes:
+    # https://github.com/kubernetes/kubernetes/issues/58662
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "_status/vars"
+    prometheus.io/port: "{{ .Values.HttpPort }}"
+spec:
+  ports:
+  - port: {{ .Values.GrpcPort }}
+    targetPort: {{ .Values.GrpcPort }}
+    name: grpc
+  - port: {{ .Values.HttpPort }}
+    targetPort: {{ .Values.HttpPort }}
+    name: http
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other CockroachDB pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector:
+    app: {{ .Chart.Name }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Chart.Name }}-budget
+  namespace: {{ .Values.namespace}}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  maxUnavailable: 1
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Values.namespace}}
+spec:
+  serviceName: "{{ .Chart.Name }}"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      serviceAccountName: {{ .Chart.Name }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ .Chart.Name }}
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ .Values.image }}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: {{ .Values.GrpcPort }}
+          name: grpc
+        - containerPort: {{ .Values.HttpPort }}
+          name: http
+        livenessProbe:
+          httpGet:
+            path: "/health"
+            port: http
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: "/health?ready=1"
+            port: http
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 2
+        volumeMounts:
+        - name: datadir
+          mountPath: /cockroach/cockroach-data
+        - name: certs
+          mountPath: /cockroach/cockroach-certs
+        env:
+        - name: COCKROACH_CHANNEL
+          value: {{ .Values.cockroachChannel}}
+        command:
+          - "/bin/bash"
+          - "-ecx"
+          # The use of qualified `hostname -f` is crucial:
+          # Other nodes aren't able to look up the unqualified hostname.
+          - "exec /cockroach/cockroach start --logtostderr --certs-dir /cockroach/cockroach-certs --advertise-addr {{ .Values.PublicAddr }} --locality-advertise-addr=zone={{ .Values.namespace }}@$(hostname -f) --http-addr 0.0.0.0 --join {{ if .Values.JoinExisting }}{{ join "," .Values.JoinExisting }}{{ else }}cockroachdb-0.cockroachdb.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.GrpcPort }},cockroachdb-1.cockroachdb.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.GrpcPort }},cockroachdb-2.cockroachdb.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.GrpcPort }}{{ end }} --locality=zone={{ .Values.namespace}} --cache 25% --max-sql-memory 25%"
+      # No pre-stop hook is required, a SIGTERM plus some time is all that's
+      # needed for graceful shutdown of a node.
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: datadir
+        persistentVolumeClaim:
+          claimName: datadir
+      - name: certs
+        secret:
+          secretName: {{ .Chart.Name }}.node
+          defaultMode: 256
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+    spec:
+      storageClassName: {{ .Values.storageClass }}
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: {{ .Values.storageSize }}
+

--- a/new-config/templates/dns-lb.yaml
+++ b/new-config/templates/dns-lb.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    # TODO: Check whether AWS/Azure can use internal load balancers. Google
+    # can't, unfortunately.
+    # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    # service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    # cloud.google.com/load-balancer-type: "Internal"
+  labels:
+    k8s-app: kube-dns
+  name: kube-dns-lb
+  namespace: kube-system
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  selector:
+    k8s-app: kube-dns
+  sessionAffinity: None
+  type: LoadBalancer

--- a/new-config/templates/external-name-svc.yaml
+++ b/new-config/templates/external-name-svc.yaml
@@ -1,0 +1,45 @@
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}-public
+spec:
+  type: ExternalName
+  externalName: {{ .Chart.Name }}-public.{{ .Values.namespace }}.svc.cluster.local
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Chart.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Chart.Name }}
+  namespace: default

--- a/new-config/templates/grpc-backend.skip
+++ b/new-config/templates/grpc-backend.skip
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grpc-backend
+  labels:
+    app: grpc-backend
+  annotations:
+    # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "_status/vars"
+    prometheus.io/port: "8080"
+spec:
+  ports:
+  - port: 8081
+    targetPort: 8081
+    name: grpc
+  selector:
+    app: grpc-backend
+  type: LoadBalancer
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: grpc-backend
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: grpc-backend
+    spec:
+      volumes:
+      - name: client-certs
+        secret:
+          secretName: cockroachdb.client.root
+          defaultMode: 256
+      - name: public-certs
+        secret:
+          secretName: dss.public.certs
+          defaultMode: 256
+      containers:
+      - name: grpc-backend
+        image: grpc-backend:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8081
+          name: grpc
+        volumeMounts:
+        - name: client-certs
+          mountPath: /cockroach-certs
+        - name: public-certs
+          mountPath: /public-certs
+        command:
+          - "/bin/bash"
+          - "-ecx"
+          - "exec ./main.go -addr=:8081 -public_key_file=/public-certs/oauth.pem"

--- a/new-config/templates/http-gateway.skip
+++ b/new-config/templates/http-gateway.skip
@@ -1,0 +1,22 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: http-gateway
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: http-gateway
+    spec:
+      containers:
+      - name: http-gateway
+        image: http-gateway:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: http
+        command:
+          - "/bin/bash"
+          - "-ecx"
+          - "exec ./main.go  -grpc-backend=grpc-backend.{{ .Values.namespace }}:TARGET_PORT -port=8080"

--- a/new-config/templates/loadbalancer.yaml
+++ b/new-config/templates/loadbalancer.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # This service is meant to be used by clients of the database. It exposes a ClusterIP that will
+  # automatically load balance connections to the different database pods.
+  name: cockroachdb-public
+  labels:
+    app: cockroachdb
+spec:
+  ports:
+  # The main port, served by gRPC, serves Postgres-flavor SQL, internode
+  # traffic and the cli.
+  - port: 26257
+    targetPort: 26257
+    name: grpc
+  # The secondary port serves the UI as well as health and debug endpoints.
+  - port: 8080
+    targetPort: 8080
+    name: http
+  selector:
+    app: cockroachdb
+  type: LoadBalancer

--- a/new-config/templates/loadbalancer.yaml
+++ b/new-config/templates/loadbalancer.yaml
@@ -19,4 +19,5 @@ spec:
     name: http
   selector:
     app: cockroachdb
+  sessionAffinity: ClientIP
   type: LoadBalancer

--- a/new-config/templates/rolebinding.yaml
+++ b/new-config/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if eq .Values.psp.roleBinding true }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default:privileged
+  namespace: { .Values.namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.psp.roleRef }}
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:{{ .Values.namespace}}
+{{- end }}

--- a/new-config/values.yaml
+++ b/new-config/values.yaml
@@ -1,0 +1,16 @@
+# Required
+PublicAddr: # Public load balancer IP that was generated from make-certs.py
+namespace:
+storageClass: # Name of the storage class for your cluster you want the nodes to use. (i.e. managed-premium)
+
+#Optionally edit
+image: cockroachdb/cockroach:v19.1.3
+clusterInit: false
+psp: #You will likely need this if PSP is turned on.
+  roleBinding: false
+  roleRef:
+cockroachChannel: kubernetes-multiregion
+storageSize: 100Gi
+GrpcPort: 26257
+HttpPort: 8080
+JoinExisting: []


### PR DESCRIPTION
- Strip down python script to just generate certs and a load balancer
- Bash script stripped down to just apply secret certificates
- Switching to helm templating for YAML rendering
- Skip http-gateway and grpc-backend for now
- Added support for PSP RBAC, Storage Class
- Switch references of "zone" to "namespace"